### PR TITLE
Create build.json

### DIFF
--- a/meter-reader/build.json
+++ b/meter-reader/build.json
@@ -1,0 +1,11 @@
+{
+  "squash": false,
+  "build_from": {
+    "aarch64": "hassioaddons/base-aarch64:7.1.0",
+    "amd64": "hassioaddons/base-amd64:7.1.0",
+    "armhf": "hassioaddons/base-armhf:7.1.0",
+    "armv7": "hassioaddons/base-armv7:7.1.0",
+    "i386": "hassioaddons/base-i386:7.1.0"
+  },
+  "args": {}
+}


### PR DESCRIPTION
Allows to install on HassOS 4.11 and solves Issue #3. 
Source : https://community.home-assistant.io/t/local-addon-suddenly-build-errors-since-hassos-4-10-0-111/204126/4?u=alexbelgium
Tested.