### PR TITLE
Remove "devices"

### DIFF
--- a/oru/config.json
+++ b/oru/config.json
@@ -9,7 +9,6 @@
   "homeassistant": "0.92.0b2",
   "boot": "auto",
   "map": ["share:rw", "ssl"],
-  "devices": ["/dev/bus/usb:/dev/bus/usb:rwm"],
   "host_network": "False",
   "arch": [
     "aarch64",


### PR DESCRIPTION
Got error:  Add-on config 'devices' use a deprecated format, the new format uses a list of paths only. Please report this to the maintainer of Orange and Rockland Utility to MQTT Bridge. 

I believe this is no longer needed and can be removed. 