### PR TITLE
make account_number optional

### DIFF
--- a/oru/config.json
+++ b/oru/config.json
@@ -42,7 +42,7 @@
     "mfa_secret": "str",
     "account_uuid": "str",
     "meter_number": "str",
-    "account_number": "str",
+    "account_number": "str?",
     "site": "str",
     "mqtt_host": "str",
     "mqtt_user": "str",


### PR DESCRIPTION
fixes issue #28

there is a bad code path [here](https://github.com/bvlaicu/coned/blob/26d11bcd4c6cba0b1d9a8a0a148983f688b86b36/coned/meter.py#L198) in meter.py for when account_number is set that doesn't work properly (throws errors around `raw_data`)

the home assistant plugin was forcing this field which made it impossible to avoid the path.  for now, allow account_number to be optional